### PR TITLE
adding cram support, updating gatk path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN apt-get update -y && apt-get install -y \
     bzip2 \
     default-jre \
     wget \
-    zlib1g-dev #for pysam
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev
 
 RUN cd /tmp/ \
-    && wget -O /tmp/gatk3.6.tar.bz2 'https://software.broadinstitute.org/gatk/download/auth?package=GATK-archive&version=3.6-0-g89b7209' \
+    && wget -O /tmp/gatk3.6.tar.bz2 'https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.6-0-g89b7209.tar.bz2' \
     && tar xf gatk3.6.tar.bz2 \
     && cp GenomeAnalysisTK.jar /opt/GenomeAnalysisTK.jar \
     && rm -rf /tmp/*
@@ -24,5 +26,5 @@ RUN cd /tmp/ \
 ##############
 COPY mapq0_vcf_filter.sh /usr/bin/mapq0_vcf_filter.sh
 RUN chmod +x /usr/bin/mapq0_vcf_filter.sh
-RUN pip3 install pysam
-RUN pip3 install pysamstats
+RUN pip3 install pysam==0.15.4
+RUN pip3 install pysamstats==1.1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update -y && apt-get install -y \
     apt-utils \
     bzip2 \
     default-jre \
-    wget \
-    zlib1g-dev \
     libbz2-dev \
-    liblzma-dev
+    liblzma-dev \
+    wget \
+    zlib1g-dev
 
 RUN cd /tmp/ \
     && wget -O /tmp/gatk3.6.tar.bz2 'https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.6-0-g89b7209.tar.bz2' \


### PR DESCRIPTION
1) The older version of pysam in the last build didn't support cram properly.  I updated some deps and pinned the versions to fix that.

2) the GATK path referenced had been removed, thanks to their migration to the cloud.  Updated path should be stable and seems to work