### PR TITLE
Correcting some errors in the MAPQ0 calculation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,16 @@ FROM griffithlab/vatools:4.1.0
 LABEL \
     description="tools needed for mapq0 filter"
 
+RUN apt-get update -y && apt-get install -y \
+    apt-utils \
+    bzip2 \
+    libbz2-dev \
+    liblzma-dev \
+    zlib1g-dev
+
 COPY mapq0_vcf_filter.sh /usr/bin/mapq0_vcf_filter.sh
 COPY add_mq0_and_filter.py /usr/bin/add_mq0_and_filter.py
 RUN chmod +x /usr/bin/mapq0_vcf_filter.sh /usr/bin/add_mq0_and_filter.py
 RUN pip3 install cython==0.29.19
-RUN pip3 install pysam==0.15.4
+RUN pip3 install pysam==0.16.0.1
 RUN pip3 install pysamstats==1.1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,11 @@
-FROM griffithlab/vatools:3.0.1
+FROM griffithlab/vatools:4.1.0
 
 LABEL \
     description="tools needed for mapq0 filter"
 
-##########
-#GATK 3.6#
-##########
-RUN apt-get update -y && apt-get install -y \
-    apt-utils \
-    bzip2 \
-    default-jre \
-    libbz2-dev \
-    liblzma-dev \
-    wget \
-    zlib1g-dev
-
-RUN cd /tmp/ \
-    && wget -O /tmp/gatk3.6.tar.bz2 'https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.6-0-g89b7209.tar.bz2' \
-    && tar xf gatk3.6.tar.bz2 \
-    && cp GenomeAnalysisTK.jar /opt/GenomeAnalysisTK.jar \
-    && rm -rf /tmp/*
-
-##############
-#mapq0 filter
-##############
 COPY mapq0_vcf_filter.sh /usr/bin/mapq0_vcf_filter.sh
-RUN chmod +x /usr/bin/mapq0_vcf_filter.sh
+COPY add_mq0_and_filter.py /usr/bin/add_mq0_and_filter.py
+RUN chmod +x /usr/bin/mapq0_vcf_filter.sh /usr/bin/add_mq0_and_filter.py
 RUN pip3 install cython==0.29.19
 RUN pip3 install pysam==0.15.4
 RUN pip3 install pysamstats==1.1.2

--- a/add_mq0_and_filter.py
+++ b/add_mq0_and_filter.py
@@ -1,0 +1,116 @@
+import argparse
+import sys
+import vcfpy
+import csv
+from collections import OrderedDict
+
+def to_array(dictionary):
+    array = []
+    for key, value in dictionary.items():
+        array.append("{}|{}".format(key, value))
+    return sorted(array)
+
+def parse_tsv_file(args):
+    values={}
+    with open(args.values_file,'r') as tsvin:
+        tsvin = csv.reader(tsvin, delimiter='\t')
+        for row in tsvin:
+            if any(x.strip() for x in row): #skip blank lines
+                values[(row[0] + ":" + row[1])] = row[2]
+    return values
+
+
+def create_vcf_reader(args):
+    vcf_reader = vcfpy.Reader.from_path(args.input_vcf)
+    if 'MQ0' in vcf_reader.header.format_ids():
+        print("FORMAT already contains a MQ0 field. It's value will be overwritten when matches are found")
+    if 'MQ0PERC' in vcf_reader.header.format_ids() :
+        print("FORMAT already contains a MQ0PERC field. It's value will be overwritten when matches are found")
+    return vcf_reader
+
+def create_vcf_writer(args, vcf_reader):
+    if args.output_vcf:
+        output_file = args.output_vcf
+    else:
+        (head, sep, tail) = args.input_vcf.rpartition('.vcf')
+        output_file = ('').join([head, '.info.vcf', tail])
+
+    new_header = vcf_reader.header.copy()
+
+    if not 'MQ0' in vcf_reader.header.format_ids():
+        od = OrderedDict([('ID', 'MQ0'), ('Number', '1'), ('Type', 'Float'), ('Description', 'Number of MAPQ == 0 reads covering this site in the tumor')])
+        new_header.add_format_line(od)
+    if not 'MQ0PERC' in vcf_reader.header.format_ids():    
+        od2 = OrderedDict([('ID', 'MQ0PERC'), ('Number', '1'), ('Type', 'Float'), ('Description', 'Percentage of MAPQ == 0 reads covering this site in the tumor')])
+        new_header.add_format_line(od2)
+    if not 'MQ0PERC' in vcf_reader.header.filter_ids():    
+        od3 = OrderedDict([('ID', 'MAPQ0'), ('Description', 'Site exceeds {} percent reads with mapping quality zero'.format(args.mq0perc_threshold))])
+        new_header.add_filter_line(od3)
+
+    return vcfpy.Writer.from_path(output_file, new_header)
+
+def define_parser():
+    parser = argparse.ArgumentParser(
+        "vcf-mapq-filter",
+        description = "A tool that will add mapping quality data from a tab-delimited file to a MQ0 field" +
+                      "field in VCF INFO column, then apply a filter to sites with greater than a" +
+                      "specified percentage of reads with MAPQ0 in the tumor sample."
+    )
+
+    parser.add_argument(
+        "input_vcf",
+        help="A VCF file"
+    )
+    parser.add_argument(
+        "values_file",
+        help="A TSV file containing three columns: chromosome, position, value"
+    )
+    parser.add_argument(
+        "sample_name",
+        help="The sample name from which the MQ0 values were extracted. Expected to have a DP value"
+    )
+    parser.add_argument(
+        "mq0perc_threshold",
+        help="lines with MQ0PERC above this value will be labeled MAPQ0 in the FILTER field"
+    )
+    parser.add_argument(
+        "output_vcf",
+        help="Path to write the output VCF file"
+    )
+    return parser
+
+def main(args_input = sys.argv[1:]):
+    parser = define_parser()
+    args = parser.parse_args(args_input)
+
+    vcf_reader  = create_vcf_reader(args)
+    vcf_writer = create_vcf_writer(args, vcf_reader)
+
+    values = parse_tsv_file(args)
+
+    for entry in vcf_reader:
+        if "MQ0" not in entry.FORMAT:
+            if isinstance(entry.FORMAT, tuple):
+                entry.FORMAT = ["MQ0"]
+            else:
+                entry.FORMAT.append('MQ0')
+        if "MQ0PERC" not in entry.FORMAT:
+            if isinstance(entry.FORMAT, tuple):
+                entry.FORMAT = ["MQ0PERC"]
+            else:
+                entry.FORMAT.append('MQ0PERC')
+
+        if entry.CHROM + ":" + str(entry.POS) in values:
+            mq0perc = float(values[entry.CHROM + ":" + str(entry.POS)])/float(entry.call_for_sample[args.sample_name].data['DP'])
+            entry.call_for_sample[args.sample_name].data['MQ0'] = values[entry.CHROM + ":" + str(entry.POS)]
+            entry.call_for_sample[args.sample_name].data['MQ0PERC'] = round(mq0perc,4)
+            if mq0perc > float(args.mq0perc_threshold):
+                entry.add_filter('MAPQ0')
+                
+        vcf_writer.write_record(entry)
+
+    vcf_reader.close()
+    vcf_writer.close()
+
+if __name__ == '__main__':
+    main()

--- a/add_mq0_and_filter.py
+++ b/add_mq0_and_filter.py
@@ -43,7 +43,7 @@ def create_vcf_writer(args, vcf_reader):
     if not 'MQ0FRAC' in vcf_reader.header.format_ids():    
         od2 = OrderedDict([('ID', 'MQ0FRAC'), ('Number', '1'), ('Type', 'Float'), ('Description', 'Fraction of MAPQ == 0 reads covering this site in the tumor')])
         new_header.add_format_line(od2)
-    if not 'MQ0FRAC' in vcf_reader.header.filter_ids():    
+    if not 'MAPQ0' in vcf_reader.header.filter_ids():    
         od3 = OrderedDict([('ID', 'MAPQ0'), ('Description', 'Site exceeds {} fraction of reads with mapping quality zero'.format(args.mq0frac_threshold))])
         new_header.add_filter_line(od3)
 
@@ -83,7 +83,7 @@ def main(args_input = sys.argv[1:]):
     parser = define_parser()
     args = parser.parse_args(args_input)
 
-    vcf_reader  = create_vcf_reader(args)
+    vcf_reader = create_vcf_reader(args)
     vcf_writer = create_vcf_writer(args, vcf_reader)
 
     values = parse_tsv_file(args)

--- a/add_mq0_and_filter.py
+++ b/add_mq0_and_filter.py
@@ -4,12 +4,6 @@ import vcfpy
 import csv
 from collections import OrderedDict
 
-def to_array(dictionary):
-    array = []
-    for key, value in dictionary.items():
-        array.append("{}|{}".format(key, value))
-    return sorted(array)
-
 def parse_tsv_file(args):
     values={}
     with open(args.values_file,'r') as tsvin:
@@ -23,9 +17,9 @@ def parse_tsv_file(args):
 def create_vcf_reader(args):
     vcf_reader = vcfpy.Reader.from_path(args.input_vcf)
     if 'MQ0' in vcf_reader.header.format_ids():
-        print("FORMAT already contains a MQ0 field. It's value will be overwritten when matches are found")
+        print("FORMAT already contains a MQ0 field. Existing values will be overwritten when matches are found.")
     if 'MQ0FRAC' in vcf_reader.header.format_ids() :
-        print("FORMAT already contains a MQ0FRAC field. It's value will be overwritten when matches are found")
+        print("FORMAT already contains a MQ0FRAC field. Existing values will be overwritten when matches are found.")
     return vcf_reader
 
 def create_vcf_writer(args, vcf_reader):
@@ -52,8 +46,8 @@ def create_vcf_writer(args, vcf_reader):
 def define_parser():
     parser = argparse.ArgumentParser(
         "vcf-mapq-filter",
-        description = "A tool that will add mapping quality data from a tab-delimited file to a MQ0 field" +
-                      "field in VCF INFO column, then apply a filter to sites with greater than a" +
+        description = "A tool that will add mapping quality data from a tab-delimited file to a MQ0 " +
+                      "field in VCF INFO column, then apply a filter to sites with greater than a " +
                       "specified fraction of reads with MAPQ0 in the tumor sample."
     )
 
@@ -63,7 +57,7 @@ def define_parser():
     )
     parser.add_argument(
         "values_file",
-        help="A TSV file containing three columns: chromosome, position, value"
+        help="A TSV file of mapq0 counts containing three columns: chromosome, position, value"
     )
     parser.add_argument(
         "sample_name",
@@ -100,9 +94,10 @@ def main(args_input = sys.argv[1:]):
             else:
                 entry.FORMAT.append('MQ0FRAC')
 
-        if entry.CHROM + ":" + str(entry.POS) in values:
-            mq0frac = float(values[entry.CHROM + ":" + str(entry.POS)])/float(entry.call_for_sample[args.sample_name].data['DP'])
-            entry.call_for_sample[args.sample_name].data['MQ0'] = values[entry.CHROM + ":" + str(entry.POS)]
+        key = entry.CHROM + ":" + str(entry.POS) 
+        if key in values:
+            mq0frac = float(values[key])/float(entry.call_for_sample[args.sample_name].data['DP'])
+            entry.call_for_sample[args.sample_name].data['MQ0'] = values[key]
             entry.call_for_sample[args.sample_name].data['MQ0FRAC'] = round(mq0frac,4)
             if mq0frac > float(args.mq0frac_threshold):
                 entry.add_filter('MAPQ0')

--- a/mapq0_vcf_filter.sh
+++ b/mapq0_vcf_filter.sh
@@ -4,49 +4,26 @@ set -e
 outvcf=$1
 vcf=$2
 bam=$3
-ref_fasta=$4
-mapq0perc=$5
+mapq0perc=$4
+sample_name=$5
 outdir=$(dirname "$outvcf")
 
-#grab sites that don't already have the MQ0 field
-zgrep -v "^#" "$vcf" | grep -v "MQ0" | cut -f 1,2 | while read chr pos;do
+count=0;
+zgrep -v "^#" "$vcf" | cut -f 1,2 | while read chr pos;do
     pysamstats --type mapq --chromosome $chr --start $pos --end $((pos+1)) "$bam"  | grep $pos | cut -f 1,2,5 >>$outdir/mapq0counts
+    count=$((count+1))
 done
 
 
-if [[ ! -s $outdir/mapq0counts ]];then
-    #no sites to process, just make a copy of the vcf. 
-    #Have to handle both gzipped and unzipped vcfs
+if [[ $count -eq 0 ]];then
+    #no sites to process, just make a copy of the (empty) vcf.
+    #handle both gzipped and unzipped vcfs
     if [[ ${vcf: -3} == ".gz" ]];then 
-        gunzip -c $vcf > $outdir/mapq0.vcf
+        gunzip -c $vcf > $outdir/mapq_filtered.vcf.gz
     else
-        cp $vcf $outdir/mapq0.vcf
+        cp $vcf $outdir/mapq_filtered.vcf.gz
     fi
 else 
-    #need to add MQ0
-    
-    #does the file contain the MQ0 field already?
-    mqcount=0
-    case "$vcf" in
-        *.gz | *.tgz )
-            #gzipped vcf
-            mqcount=$(gunzip -c "$vcf" | grep "^#" | grep -w MQ0 | wc -l)
-            ;;
-        *)
-            #non-gzipped vcf
-            mqcount=$(grep "^#" "$vcf" | grep -w MQ0 | wc -l)
-            ;;
-    esac
-    
-    if [[ $mqcount -gt 0 ]];then
-        #already has mq0 set, we're all good
-        vcf-info-annotator --overwrite -o $outdir/mapq0.vcf "$vcf" $outdir/mapq0counts MQ0 
-    else
-        #no mq0, need to set the header line as well
-        vcf-info-annotator -o $outdir/mapq0.vcf -f Integer -d "Number of MAPQ == 0 reads covering this record" "$vcf" $outdir/mapq0counts MQ0
-    fi
+    #process each line, add MQ0 and MQ0PERC values to the right sample, and add MAPQ0 filter when needed
+    python3 /usr/bin/add_mq0_and_filter.py $vcf mapq0counts $sample_name mapq0perc $outdir/mapq_filtered.vcf.gz
 fi
-#finally, set the filter tags on the vcf
-#the multiplication by 1.0 is necessary to convert integers to floats before dividing in the JEXL expression 
-#(which is dumb, and I want an hour of my life back)
-java -Xmx6g -jar /opt/GenomeAnalysisTK.jar -T VariantFiltration -R $ref_fasta -o $outdir/mapq_filtered.vcf.gz --variant $outdir/mapq0.vcf --filterExpression "((MQ0*1.0) / (DP*1.0)) > $mapq0perc" --filterName "MAPQ0"

--- a/mapq0_vcf_filter.sh
+++ b/mapq0_vcf_filter.sh
@@ -19,9 +19,9 @@ if [[ $count -eq 0 ]];then
     #no sites to process, just make a copy of the (empty) vcf.
     #handle both gzipped and unzipped vcfs
     if [[ ${vcf: -3} == ".gz" ]];then 
-        gunzip -c $vcf > $outdir/mapq_filtered.vcf.gz
-    else
         cp $vcf $outdir/mapq_filtered.vcf.gz
+    else
+        gzip -c $vcf > $outdir/mapq_filtered.vcf.gz
     fi
 else 
     #process each line, add MQ0 and MQ0PERC values to the right sample, and add MAPQ0 filter when needed


### PR DESCRIPTION
Several issues existed in this filter:

1) the DP field being used was generally pre-populated in the INFO field.  This DP can have different meanings from different callers, but often is far higher than the effective depth at the site.  Varscan, in particular, seems to fill it with the sum of the tumor and normal reads pre-quality filtering, which is not really what is wanted here. Rather, we want to use the DP value in the FORMAT field for a particular sample (generally the tumor sample)

2) The MQ0 field being used was sometimes pre-populated in the INFO field, again depending on which variant caller was used.  This value could have different definitions from different callers as well, and so the safe thing to do is to calculate it again from every site and assign a new MQ0 value to the specified sample in the FORMAT field.  (It remains to be seen whether this will be a bottleneck in terms of speed on very large datasets - I'll do some testing soon)

3) Even if we wanted to used pre-populated MQ0 values, they're in the INFO field, and there isn't a straightforward way to use JEXL/VariantFiltration to grab values from both FORMAT and INFO to compare them.  This, and several preceding steps, have been replaced with a small python tool that reads a file of MQ0 counts, drops them into the VCF, and sets the FILTER field, all at the same time.  This is more efficient and easier to understand.

Because of the DP issue in 1, previous results run through this tool may have been filtered less stringently than desired.  I haven't yet found a case where DP was unexpectedly low, which means false negatives should not have been an issue.