### PR TITLE
Don't try to filter entries with no `DP` field

### DIFF
--- a/add_mq0_and_filter.py
+++ b/add_mq0_and_filter.py
@@ -94,7 +94,7 @@ def main(args_input = sys.argv[1:]):
             else:
                 entry.FORMAT.append('MQ0FRAC')
 
-        key = entry.CHROM + ":" + str(entry.POS) 
+        key = entry.CHROM + ":" + str(entry.POS)
         if "DP" in entry.FORMAT:
             if key in values:
                 mq0frac = float(values[key])/float(entry.call_for_sample[args.sample_name].data['DP'])
@@ -102,7 +102,7 @@ def main(args_input = sys.argv[1:]):
                 entry.call_for_sample[args.sample_name].data['MQ0FRAC'] = round(mq0frac,4)
                 if mq0frac > float(args.mq0frac_threshold):
                     entry.add_filter('MAPQ0')
-                
+
         vcf_writer.write_record(entry)
 
     vcf_reader.close()

--- a/add_mq0_and_filter.py
+++ b/add_mq0_and_filter.py
@@ -102,6 +102,10 @@ def main(args_input = sys.argv[1:]):
                 entry.call_for_sample[args.sample_name].data['MQ0FRAC'] = round(mq0frac,4)
                 if mq0frac > float(args.mq0frac_threshold):
                     entry.add_filter('MAPQ0')
+            else:
+                print("No MQ0 value found for " + key, file=sys.stderr)
+        else:
+            print("No DP value in VCF for " + key, file=sys.stderr)
 
         vcf_writer.write_record(entry)
 

--- a/add_mq0_and_filter.py
+++ b/add_mq0_and_filter.py
@@ -95,12 +95,13 @@ def main(args_input = sys.argv[1:]):
                 entry.FORMAT.append('MQ0FRAC')
 
         key = entry.CHROM + ":" + str(entry.POS) 
-        if key in values:
-            mq0frac = float(values[key])/float(entry.call_for_sample[args.sample_name].data['DP'])
-            entry.call_for_sample[args.sample_name].data['MQ0'] = values[key]
-            entry.call_for_sample[args.sample_name].data['MQ0FRAC'] = round(mq0frac,4)
-            if mq0frac > float(args.mq0frac_threshold):
-                entry.add_filter('MAPQ0')
+        if "DP" in entry.FORMAT:
+            if key in values:
+                mq0frac = float(values[key])/float(entry.call_for_sample[args.sample_name].data['DP'])
+                entry.call_for_sample[args.sample_name].data['MQ0'] = values[key]
+                entry.call_for_sample[args.sample_name].data['MQ0FRAC'] = round(mq0frac,4)
+                if mq0frac > float(args.mq0frac_threshold):
+                    entry.add_filter('MAPQ0')
                 
         vcf_writer.write_record(entry)
 


### PR DESCRIPTION
If we don't have depth information we can't calculate the `MQ0FRAC` to run this filter, so just pass the variant through.